### PR TITLE
Update build.gradle

### DIFF
--- a/flutter/flutter/android/build.gradle
+++ b/flutter/flutter/android/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 //    implementation 'com.arthenica:ffmpeg-kit-https:6.0-2'
 //    FmpegKit has been officially retired.Place dependent libraries locally
 //    The Maven configuration is immutable and currently not required; it’s retained solely as a precaution.
-    implementation files('./libs/ffmpeg-kit-https-6.0-2.aar')
+    compileOnly files('./libs/ffmpeg-kit-https-6.0-2.aar')
 
 //start:    smart-exception-java
     implementation files('./libs/smart-exception-java-0.2.1.jar')


### PR DESCRIPTION
fix ffmpeg-kit-https-6.0-2.aar to compileOnly

## Description
Describe the change and/or the issue fixed in this pull request. 
Please also include the context and motivation about the changes introduced.

## Type of Change
- New feature
- Bug fix
- Documentation

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [ ] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
How are these changes verified? Please provide test instructions.
Also list any relevant details about your test configuration.